### PR TITLE
fix: remove admin user creation todo comment

### DIFF
--- a/cmd/lite/lite.go
+++ b/cmd/lite/lite.go
@@ -127,8 +127,6 @@ var rootCmd = &cobra.Command{
 			memcache,
 		)
 
-		// todo: check if we have an admin user
-		// if not, create an admin user with the ADMIN_PASSWORD ENV
 		err = authService.CreateAdminUser()
 		if err != nil {
 			slog.Error("failed to create admin user", slog.Any("error", err))


### PR DESCRIPTION
The CreateAdminUser() call already checks if an admin user exists or not before creating a new one.

While working on making some changes I saw the comment and that it seems already resolved.