### PR TITLE
feat: add --disable-otel / DISABLE_OTEL to disable otel trace export

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -16,5 +16,7 @@ CLICKHOUSE_DATABASE=default
 CLICKHOUSE_USERNAME=default
 CLICKHOUSE_PASSWORD=password
 
+DISABLE_OTEL=false
+
 VERSION=dev # dev only
 ENV=dev # dev only

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The application is configured via environment variables.
 | `CLICKHOUSE_PASSWORD` | ClickHouse password | `password` |
 | `CLICKHOUSE_DATABASE` | ClickHouse database name | `default` |
 | `ENV` | Environment mode (`production` or `dev`) | `dev` |
+| `DISABLE_OTEL` | Disable OpenTelemetry integration (true/false) | `false` |
 
 ---
 

--- a/cmd/lite/lite.go
+++ b/cmd/lite/lite.go
@@ -48,7 +48,7 @@ var rootCmd = &cobra.Command{
 
 		slog.Info("starting Fivemanage application", slog.String("version", Version))
 
-		otelShutdown, err := otel.SetupTracer()
+		otelShutdown, err := otel.SetupTracer(viper.GetBool("disable-otel"))
 		if err != nil {
 			slog.Error("failed to setup OpenTelemetry", slog.Any("error", err))
 		}
@@ -185,6 +185,8 @@ func init() {
 	// s3
 	rootCmd.Flags().String("s3-provider", "minio", "S3 provider")
 	rootCmd.Flags().String("bucket-domain", "", "Bucket domain for file storage")
+	// otel
+	rootCmd.Flags().Bool("disable-otel", false, "Disable OpenTelemetry")
 
 	// fuck me
 	if err := viper.BindPFlag("port", rootCmd.Flags().Lookup("port")); err != nil {
@@ -218,6 +220,9 @@ func init() {
 		bindError(err)
 	}
 	if err := viper.BindEnv("bucket-domain", "BUCKET_DOMAIN"); err != nil {
+		bindError(err)
+	}
+	if err := viper.BindEnv("disable-otel", "DISABLE_OTEL"); err != nil {
 		bindError(err)
 	}
 

--- a/pkg/otel/exporter.go
+++ b/pkg/otel/exporter.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 const (
@@ -19,9 +20,9 @@ const (
 	otlpEndpoint = "localhost:4318"
 )
 
-func SetupTracer() (func(context.Context) error, error) {
+func SetupTracer(disabled bool) (func(context.Context) error, error) {
 	ctx := context.Background()
-	return InstallExportPipeline(ctx)
+	return InstallExportPipeline(ctx, disabled)
 }
 
 func Resource() *resource.Resource {
@@ -34,7 +35,14 @@ func Resource() *resource.Resource {
 	)
 }
 
-func InstallExportPipeline(ctx context.Context) (func(context.Context) error, error) {
+func InstallExportPipeline(ctx context.Context, disabled bool) (func(context.Context) error, error) {
+	if disabled {
+		tracerProvider := noop.NewTracerProvider()
+		otel.SetTracerProvider(tracerProvider)
+
+		return func(context.Context) error { return nil }, nil
+	}
+
 	var tlsOption otlptracehttp.Option
 	if os.Getenv("ENV") == "dev" {
 		tlsOption = otlptracehttp.WithInsecure()


### PR DESCRIPTION
Add flag/env var to allow disabling OTEL export/traces.

This should eliminate logs such as this when there isn't OTEL export available at `localhost:4318`:

```
[09:59:59.043] INFO: traces export: Post "https://localhost:4318/v1/traces": dial tcp [::1]:4318: connect: connection refused
[09:34:34.057] INFO: traces export: Post "https://localhost:4318/v1/traces": dial tcp [::1]:4318: connect: connection refused
[09:49:49.062] INFO: traces export: Post "https://localhost:4318/v1/traces": dial tcp [::1]:4318: connect: connection refused
```

---

Are there any steps I'm missing to build the project? I can't seem to build it due to "docs" pkg missing:
```
internal/http/publicapi/public_api.go:11:2: no required module provides package github.com/fivemanage/lite/docs; to add it:
        go get github.com/fivemanage/lite/docs
```
Looking around, the `web/package.json` target `generate:api` accesses the `docs/` dir as well, but there is no `docs/` dir after following the steps from the `README.md`.
I would appreciate any hints to get it to build locally so I can test it and also look into fixing another issue (nil panics when clickhouse is disabled/not used).